### PR TITLE
Use specialized exceptions when reporting missing joint names

### DIFF
--- a/tasks/Conversions.cpp
+++ b/tasks/Conversions.cpp
@@ -99,7 +99,7 @@ void jointState2RmlTypes(const base::samples::Joints& joint_state, const std::ve
             params.CurrentVelocityVector->VecData[i]     = 0;
             params.CurrentAccelerationVector->VecData[i] = 0;
         }
-        catch(const std::out_of_range &e){
+        catch(const base::samples::Joints::InvalidName &e){
             LOG_ERROR("Element %s has been configured in motion constraints, but is not available in joint state", names[i].c_str());
             throw e;
         }

--- a/tasks/Conversions.cpp
+++ b/tasks/Conversions.cpp
@@ -100,7 +100,7 @@ void jointState2RmlTypes(const base::samples::Joints& joint_state, const std::ve
             params.CurrentAccelerationVector->VecData[i] = 0;
         }
         catch(const base::samples::Joints::InvalidName &e){
-            LOG_ERROR("Element %s has been configured in motion constraints, but is not available in joint state", names[i].c_str());
+            LOG_ERROR("Element %s has been configured in motion constraints, but is not available in joint state", e.name.c_str());
             throw e;
         }
     }
@@ -208,7 +208,7 @@ void target2RmlTypes(const ConstrainedJointsCmd& target, const MotionConstraints
             }
         }
         catch(const MotionConstraints::InvalidName &e){
-            LOG_ERROR("Joint '%s' is in target vector but has not been configured in motion constraints", target.names[i].c_str());
+            LOG_ERROR("Joint '%s' is in target vector but has not been configured in motion constraints", e.name.c_str());
             throw e;
         }
     }
@@ -228,7 +228,7 @@ void target2RmlTypes(const ConstrainedJointsCmd& target, const MotionConstraints
             }
         }
         catch(const MotionConstraints::InvalidName &e){
-            LOG_ERROR("Joint '%s' is in target vector but has not been configured in motion constraints", target.names[i].c_str());
+            LOG_ERROR("Joint '%s' is in target vector but has not been configured in motion constraints", e.name.c_str());
             throw e;
         }
     }

--- a/tasks/Conversions.cpp
+++ b/tasks/Conversions.cpp
@@ -99,7 +99,7 @@ void jointState2RmlTypes(const base::samples::Joints& joint_state, const std::ve
             params.CurrentVelocityVector->VecData[i]     = 0;
             params.CurrentAccelerationVector->VecData[i] = 0;
         }
-        catch(std::runtime_error e){
+        catch(const std::out_of_range &e){
             LOG_ERROR("Element %s has been configured in motion constraints, but is not available in joint state", names[i].c_str());
             throw e;
         }
@@ -207,7 +207,7 @@ void target2RmlTypes(const ConstrainedJointsCmd& target, const MotionConstraints
                 motionConstraint2RmlTypes(constraint, idx, params);
             }
         }
-        catch(std::runtime_error e){
+        catch(const MotionConstraints::InvalidName &e){
             LOG_ERROR("Joint '%s' is in target vector but has not been configured in motion constraints", target.names[i].c_str());
             throw e;
         }
@@ -227,7 +227,7 @@ void target2RmlTypes(const ConstrainedJointsCmd& target, const MotionConstraints
                 motionConstraint2RmlTypes(constraint, idx, params);
             }
         }
-        catch(std::runtime_error e){
+        catch(const MotionConstraints::InvalidName &e){
             LOG_ERROR("Joint '%s' is in target vector but has not been configured in motion constraints", target.names[i].c_str());
             throw e;
         }


### PR DESCRIPTION
Both for detecting joints in the input command which have not been configured in motion constraints as well as motion constraints which have no matching joint in the joint state, any `std::runtime_error` is caught. This seems a bit overgeneralized to me, as any exception which is not actually due to the stated causes would prompt an error message which is actually wrong. For example the exception thrown [here](https://github.com/rock-control/control-orogen-trajectory_generation/blob/master/tasks/Conversions.cpp#L94) would also cause the error message to appear.

Instead I would propose to catch the actual exceptions thrown by `NamedVector::mapNameToIndex` and `NamedVector::getElementByName` (which also just uses `mapNameToIndex` internally) which would be variations of `NamedVector::InvalidName`). This also allows to simply extract the joints name from the exception when writing the error message instead of obtaining it from the arrays again.