### PR TITLE
Remove cycle_time property from comments and example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ Each component is based on the `RMLTask` task context. An example configuration 
 
   ```
   --- name:default
-  # Cycle Time is seconds. IMPORTANT: This value has to match the period of the component. Default is 0.01 which matches the default period.
-  cycle_time: 0.01
-
   # Motion constraints that define the properties of the output trajectory (command-port). These include the maximum/minimum position,
   # maximum maximum speed, maximum acceleration and maximum jerk (derivative of acceleration).
   motion_constraints:

--- a/trajectory_generation.orogen
+++ b/trajectory_generation.orogen
@@ -70,10 +70,10 @@ task_context "RMLTask" do abstract
     # Computation time needed for one cycle
     output_port "computation_time", "double"
 
-    # Difference between two consecutive calls of updateHook(). The value given on this port should match as closely as possible the configured cycle time.
+    # Difference between two consecutive calls of updateHook(). The value given on this port should match the task periodicity as closely as possible.
     output_port "actual_cycle_time", "double"
 
-    # This value has to be the same as the cycle_time property. Don't forget to change the cycle_time when you change the period.
+    # This value defines the period at which the task should run and thus determines the desired cycle_time of this component.
     periodic 0.01
 end
 


### PR DESCRIPTION
Since commit 5ad76e8a the cycle_time property has been removed. This PR solely edits comments in the orogen file accordingly and adapts the example config presented in the Readme.md file.